### PR TITLE
Update littlec.c

### DIFF
--- a/src/littlec.c
+++ b/src/littlec.c
@@ -20,7 +20,7 @@
 // Secure function compatibility
 #if !defined(_MSC_VER) || _MSC_VER < 1400
 #define strcpy_s(dest, count, source) strncpy( (dest), (source), (count) )
-#define fopen_s(pFile,filename,mode) ((*(pFile))=fopen((filename),(mode)))==NULL
+#define fopen_s(pFile,filename,mode) (((*(pFile))=fopen((filename),(mode)))==NULL)
 #endif
 
 enum tok_types {


### PR DESCRIPTION
gcc compilation warning
```c
dron@gnu:~/LittleC/gcc$ make
gcc -O -Wall -Wextra -c -o littlec.o ../src/littlec.c
../src/littlec.c: In function ‘load_program’:
../src/littlec.c:23:75: warning: suggest parentheses around comparison in operand of ‘!=’ [-Wparentheses]
 #define fopen_s(pFile,filename,mode) ((*(pFile))=fopen((filename),(mode)))==NULL
                                                                           ^
../src/littlec.c:248:6: note: in expansion of macro ‘fopen_s’
  if (fopen_s(&fp, fname, "rb") != 0 || fp == NULL) return 0;
      ^~~~~~~
gcc -O -Wall -Wextra -o littlec parser.o littlec.o lclib.o
dron@gnu:~/LittleC/gcc$ 

```